### PR TITLE
Rename to `simple-package-paths`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ---
-feature: auto-called-packages
+feature: simple-package-paths
 start-date: 2022-09-02
 author: Silvan Mosberger
 co-authors: (find a buddy later to help out with the RFC)


### PR DESCRIPTION
Kind of closes but not quite #10 because the repo should be renamed too.